### PR TITLE
added GetBool func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.DS_Store
+.idea
+
 ./log/server.log
 tags
 *.log

--- a/goenv.go
+++ b/goenv.go
@@ -90,6 +90,20 @@ func (goenv *Goenv) GetDuration(spec string, defaultValue string) time.Duration 
 	return duration
 }
 
+func (goenv *Goenv) GetBool(spec string) bool {
+	str := goenv.Get(spec, "")
+	if str == "" {
+		return false
+	}
+
+	param, err := strconv.ParseBool(str)
+	if err != nil {
+		log.Panic("goenv GetBool failed ParseBool", goenv.environment, spec, str)
+	}
+
+	return param
+}
+
 func (goenv *Goenv) Require(spec string) string {
 	value := goenv.Get(spec, "")
 	if value == "" {

--- a/goenv_test.go
+++ b/goenv_test.go
@@ -54,6 +54,22 @@ func TestGetDuration(t *testing.T) {
 	}
 }
 
+func TestGetBool(t *testing.T) {
+	goenv := NewGoenv("./test_config.yml", "config", "nil")
+
+	t.Run("bool has been found", func(t *testing.T) {
+		if goenv.GetBool("bool") != true {
+			t.Error("bool != true")
+		}
+	})
+
+	t.Run("bool is missing", func(t *testing.T) {
+		if goenv.GetBool("missing_param") != false {
+			t.Error("missing_param != false")
+		}
+	})
+}
+
 func TestRequire(t *testing.T) {
 	defer func() { recover() }()
 	goenv := NewGoenv("./test_config.yml", "config", "nil")

--- a/test_config.yml
+++ b/test_config.yml
@@ -2,6 +2,7 @@ config:
     custom: aoeu
     duration: 10s
     number: 1234
+    bool: true
 
 list:
     entries:


### PR DESCRIPTION
It would be nice to have such env func, cause there is a very high chance that we would use it in logger params and definitely kafka enabling tracing param (propagation messages with context).

```
logger:
   redirect_std_log: true


kafka:
   tracing_enabled: true
```